### PR TITLE
Update bhnet.py

### DIFF
--- a/chapter02/bhnet.py
+++ b/chapter02/bhnet.py
@@ -84,7 +84,7 @@ def client_handler(client_socket):
                 cmd_buffer += client_socket.recv(1024)
 
             # we have a valid command so execute it and send back the results
-            response = run_command(cmd_buffer)
+            response = run_command(cmd_buffer.decode())
 
             # send back the response
             client_socket.send(response)


### PR DESCRIPTION
Updating line 87 to decode the client response before running the command. This solved an issue I ran into where my Win 10 host (running as netcat server on Python 3.9) raised the following type error:  **TypeError('bytes args is not allowed on Windows')**